### PR TITLE
Update guidelines.md

### DIFF
--- a/src/content/guidelines/content/guidelines.md
+++ b/src/content/guidelines/content/guidelines.md
@@ -9,7 +9,7 @@ For specific capitalization rules for different element or component types, see 
 
 ### Sentence style
 
-Use sentence-style capitalization in text and for all text elements in the UI, except for table/grid column headers, headings for groups of toggles, and product names. Sentence style capitalizes only the first word of each sentence and proper nouns
+Use sentence-style capitalization in text and for all text elements in the UI, except for table/grid column headers and product names. Sentence style capitalizes only the first word of each sentence and proper nouns
 (such as names).
 
 **Examples:**


### PR DESCRIPTION
Updated sentence style guidance by removing toggle headers from the list of exceptions. We initially advised to use headline-style caps for toggle headers. 