### PR TITLE
Update content-glossary-intro.md

### DIFF
--- a/src/content/guidelines/content/content-glossary-intro.md
+++ b/src/content/guidelines/content/content-glossary-intro.md
@@ -1,3 +1,3 @@
-**This section covers the approved _action labels_ and _idioms_ for use in the Bluemix UI and documentation. Users rely on consistent labels for common actions to predict how to interact with an interface. Idioms are expressions that have a meaning different from the meaning of each word in the expression.**
+**This section covers the approved _action labels_ and _idioms_ for use in the IBM Cloud UI and content. Users rely on consistent labels for common actions to predict how to interact with an interface. Idioms are expressions that have a meaning different from the meaning of each word in the expression.**
 
-This section is a living document. When new terms are introduced, they will be added here. If you're looking for the product glossary, go to <a href="https://new-console.ng.bluemix.net/docs/overview/glossary/index.html" target=blank>Glossary terms for Bluemix.</a>
+This section is a living document. When new terms are introduced, they will be added here. If you're looking for the product glossary, go to the <a href="https://console.bluemix.net/docs/overview/glossary/index.html#glossary" target=blank>Glossary terms for IBM Cloud.</a>


### PR DESCRIPTION
Replaced "Bluemix" with "IBM Cloud" and updated the product glossary link.