### PR TITLE
chore(codepen): remove view in codepen link from component examples

### DIFF
--- a/src/app/components/internal/ComponentExample/ComponentExample.js
+++ b/src/app/components/internal/ComponentExample/ComponentExample.js
@@ -26,16 +26,6 @@ class ComponentExample extends Component {
       'bx--global-light-ui': component === 'tabs'
     });
 
-    const componentLink = `https://codepen.io/team/carbon/full/${codepenSlug}/`;
-
-    const viewFullRender = this.props.hideViewFullRender ? (
-      ''
-    ) : (
-      <Link className="component-example__view-full-render" target="_blank" to={componentLink}>
-        View on CodePen
-      </Link>
-    );
-
     return (
       <div className={lightUIclassnames}>
         <div className="svg--sprite" aria-hidden="true" />
@@ -43,7 +33,6 @@ class ComponentExample extends Component {
           <div className={classNames}>
             <div dangerouslySetInnerHTML={{ __html: htmlFile }} />
           </div>
-          {viewFullRender}
         </div>
         <CodeExample htmlFile={htmlFile} />
       </div>


### PR DESCRIPTION
i removed the all the consts/etc for rendering the 'view on codepen' link in component examples