### PR TITLE
docs: updated content to reference IBM Design Language

### DIFF
--- a/src/app/pages/getting-started/carbon-and-duo.js
+++ b/src/app/pages/getting-started/carbon-and-duo.js
@@ -16,7 +16,7 @@ class Duo extends React.Component {
       return <FourOhFour />;
     } else {
       return (
-        <Page label="" title="Carbon and Duo" content={contentFile} />
+        <Page label="" title="Carbon and the IBM Design Language" content={contentFile} />
       );
     }
   }

--- a/src/content/getting-started/carbon-and-duo/carbon-and-duo.md
+++ b/src/content/getting-started/carbon-and-duo/carbon-and-duo.md
@@ -1,25 +1,25 @@
-## The Duo transition
+## The updated IBM Design Language
 
-Duo—the all-new IBM Design Language—is coming to Carbon. It represents a completely fresh approach to the design of all things at IBM.
+The Carbon Design System is integrating the new IBM Design Ethos and Language. It represents a completely fresh approach to the design of all things at IBM.
 
-The Carbon team will be introducing the new Duo components and guidelines incrementally into the Carbon Design System over the next few months. You’ll notice new entries marked “experimental” being added all the time. Experimental components are not fully tested and/or vetted, but are available for designers to work with. Your feedback on these components is critical for the success of Carbon; please open a github issue from the footer of any page on the Carbon site to let the team know what you think. 
+The Carbon team will be updating components and introducing new guidelines incrementally into the Carbon Design System over the next few months. You’ll notice new entries marked “experimental” being added all the time. Experimental components are not fully tested and/or vetted, but are available for designers to work with. Your feedback on these components is critical for the success of Carbon; please open a github issue from the footer of any page on the Carbon site to let the team know what you think. 
 
 ### FAQ
 
-**What is the difference between Duo and Carbon?**
+**What is changing?**
 
-Carbon is the design system that powers many of IBM’s most successful digital products. Duo is the new redesign of the IBM Design Language which will define and guide everything designed by IBM, including software products, digital and traditional marketing, hardware, advertising, events, physical spaces, and more. Think of Carbon as the “digital manifestation” of the Design Language.    
+Carbon is the IBM Design System for digital products. The new IBM Design Language will define and guide everything designed by IBM, including software products, digital and traditional marketing, hardware, advertising, events, physical spaces, and more. The Carbon Design System is the “digital manifestation” of the Design Language.    
 
-**How do I ensure that my products are “Duo-ready”?**
+**How do I ensure that my products are ready for this transition?**
 
-Keep building with Carbon! The best way to ensure a smooth transition as Duo comes online is to adhere to the Carbon guidelines, elements and components. 
+Keep building with Carbon! The best way to ensure a smooth transition is to adhere to the Carbon Design System guidelines, elements and components. 
 
-**How will teams adopt Duo?**
+**How will teams adopt the new IBM Design Language?**
    
-The IBM Design core team will be establishing an adoption and activation program for teams who will be working with Duo. Teams will receive either in-person or remote Duo training and activation before the first version of the new design system is externally released. As we have more details about the program, we will share news on Slack, Connections, and in the IBM Design Town Hall.
+The IBM Design core team is establishing an adoption and activation program. A new <a href="https://w3.ibm.com/design/essentials">IBM Design Essentials</a> course is available. Teams will receive either in-person or remote education before the first products using the new IBM Design Language are released. We'll share news on Slack, Connections, and in the IBM Design Town Hall.
 
 ### Updates
 
-**Complete:** Duo fonts, glyphs, and experimental grid have been integrated into Carbon as of 9/13/18.
+**Complete:** New IBM Design Language fonts, glyphs, and experimental grid have been integrated into Carbon as of 9/13/18.
 
-**Coming soon:** more icons, colors, and page geometry
+**Coming soon:** More icons, colors, and page geometry


### PR DESCRIPTION
I updated the content to remove references to Duo and for clarity.

NB: We should change the url, too...but will need to liaise with web team who built https://w3.ibm.com/design/essentials, as that links to /carbon-and-duo